### PR TITLE
Adopt cancel delegate

### DIFF
--- a/HonnyakuWWDC/VideoPlayer/View/SpeechPlayer.swift
+++ b/HonnyakuWWDC/VideoPlayer/View/SpeechPlayer.swift
@@ -185,4 +185,14 @@ extension SpeechPlayer: AVSpeechSynthesizerDelegate {
 
         delegate?.didFinishPhase()
     }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        // 普通にスピーチをしていても稀にキャンセルされることがあるようだ
+        guard phrases.nextPhraseIndex() != nil else {
+            // 再生終了
+            return
+        }
+
+        delegate?.didFinishPhase()
+    }
 }


### PR DESCRIPTION
Fix #6 
AVSpeechSynthesizerDelegateのdidCancelが呼ばれてSpeechが停止することが稀にあるようだ。
その場合に動画がWaitingになって停止指定しまっていた。Delegateを実装し、didCancel時に動画をWaitにしないようにする
