### PR TITLE
Change button immediately

### DIFF
--- a/HonnyakuWWDC/VideoDetail/UseCase/TranslateUseCase.swift
+++ b/HonnyakuWWDC/VideoDetail/UseCase/TranslateUseCase.swift
@@ -3,6 +3,7 @@
 import Foundation
 
 protocol TranslateCaseProtocol {
+    func startTranslateVideoDetailState(id: String)
     func translateVideoDetail(id: String, url: URL) async throws
     func makeClipText(id: String) -> String?
 }
@@ -33,6 +34,11 @@ class TranslateUseCase: TranslateCaseProtocol {
         self.parseVideoDetailUseCase = parseVideoDetailUseCase
         self.deepLUseCase = deepLUseCase
 
+    }
+
+    /// translate がスレッド待ちですぐ始まらないので、先にprogressStateだけ開始しておく
+    func startTranslateVideoDetailState(id: String) {
+        taskProgresUseCase.setState(taskId: id, state: .processing(progress: 0.0, message: nil))
     }
 
     func translateVideoDetail(id: String, url: URL) async throws {

--- a/HonnyakuWWDC/VideoDetail/View/ControlView.swift
+++ b/HonnyakuWWDC/VideoDetail/View/ControlView.swift
@@ -39,6 +39,7 @@ struct ControlView: View {
                     Text("Not translated yet. ")
 
                     Button("Start Translate") {
+                        viewModel.startTransferStart()
                         Task {
                             await viewModel.transfer()
                         }

--- a/HonnyakuWWDC/VideoDetail/ViewModel/VideoDetailViewModel.swift
+++ b/HonnyakuWWDC/VideoDetail/ViewModel/VideoDetailViewModel.swift
@@ -41,6 +41,11 @@ class VideoDetailViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
+    /// translate がスレッド待ちですぐに始まらないので、先にprogressStateだけ開始してボタンを非表示にする
+    func startTransferStart() {
+        transferUserCase.startTranslateVideoDetailState(id: videoId)
+    }
+
     func transfer() async {
         do {
             try await transferUserCase.translateVideoDetail(id: videoId, url: url)

--- a/HonnyakuWWDC/VideoList/View/VideoListCell.swift
+++ b/HonnyakuWWDC/VideoList/View/VideoListCell.swift
@@ -10,12 +10,12 @@ struct VideoListCell: View {
     var body: some View {
         switch viewModel.state {
         case .completed:
-            NavigationLink("🎉 "+viewModel.video.title, value: viewModel.video)
+            NavigationLink("🎉 \(viewModel.video.title)", value: viewModel.video)
                 .bold()
         case let .processing(progress, _):
             NavigationLink(value: viewModel.video  ) {
                 HStack {
-                    Text(viewModel.video.title)
+                    Text("\(Image(systemName: "wand.and.rays", variableValue: Double(progress)))  \(viewModel.video.title)")
                         .bold()
                     Spacer()
                     ProgressView(value: progress)


### PR DESCRIPTION
Fix #3 

Startボタンを押してもProgress Viewが回らないのは、処理をawaitにしてTaskに入れているため、スレッドの開始待ちが発生しているようだ。awaitする前にprogress stateを変更するようにした。

Progress Viewが消えることがあるのは、OSのバグっぽいので、そちらは手をつけずにラベルの頭にImageを表示する。変数付きの system imageを使ってみた。